### PR TITLE
Default GH Link

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,4 +1,4 @@
-name: "LLNL Jekyll Template"
+name: "Jekyll-LLNL-Theme"
 author: "Ian Lee <lee1001@llnl.gov>"
 description: "LLNL Jekyll Template"
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -16,7 +16,7 @@
       <ul class="nav navbar-nav navbar-right navbar-collapse">
         <li id="home"><a href="/">Catalog</a></li>
         <li id="about" {% if page.url == "/about/" %} class="active" {% endif %}><a href="/about/">About</a></li>
-        <li id="github"><a href="https://github.com/llnl"><span class="fa fa-github fa-lg"></span></a></li>
+        <li id="github"><a href="https://github.com/llnl/{{ site.name }}"><span class="fa fa-github fa-lg"></span></a></li>
       </ul>
     </div>
 


### PR DESCRIPTION
Improved the default setup for use with GitHub pages. If the site.name variable is set to the project name, the GitHub link will be for the correct repo (rather than the top-level LLNL organization). 