### PR TITLE
Project links2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ was preinstalled, so just working from there:
     $ gem install rdiscount
 
     # Build and serve the website
-    $ jekyll serve
+    $ jekyll serve --baseurl=''
 
     # Browse to (by default) `localhost:4000` in a web browser
     $ open localhost:4000
@@ -36,7 +36,7 @@ Using [Bundler](https://bundler.io):
     $ bundle Install
 
     # Build and serve the website
-    $ bundle exec jekyll serve
+    $ bundle exec jekyll serve --baseurl=''
 
     # Browse to (by default) `localhost:4000` in a web browser
     $ open localhost:4000

--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,10 @@
-name: "Jekyll-LLNL-Theme"
+name: "LLNL Theme for Jekyll"
 author: "Ian Lee <lee1001@llnl.gov>"
 description: "LLNL Jekyll Template"
+
+# Correct linking GitHub Project pages
+# Note leading slash in baseurl
+githubrepo: Jekyll-LLNL-Theme
+baseurl: /Jekyll-LLNL-Theme
 
 permalink: pretty

--- a/_config.yml
+++ b/_config.yml
@@ -2,6 +2,4 @@ name: "Jekyll-LLNL-Theme"
 author: "Ian Lee <lee1001@llnl.gov>"
 description: "LLNL Jekyll Template"
 
-url: "http://localhost:4000"
-
 permalink: pretty

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,6 +2,9 @@
   <meta charset="utf-8">
   <title>{{ site.name }}</title>
 
+  <!-- For project-specific css, prepend URLs with {{ site.baseurl }} -->
+  <!-- Otherwise, defaults to assets from llnl.github.io  -->
+
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="shortcut icon" href="/static/assets/images/favicon.ico">
 

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -14,10 +14,10 @@
 
     <div id="siteNavbar" class="collapse navbar-collapse">
       <ul class="nav navbar-nav navbar-right navbar-collapse">
-        {% if page.title == "Home" %} <li class="active"> {% else %} <li> {% endif %}
+        {% if page.path == "index.md" %} <li class="active"> {% else %} <li> {% endif %}
           <a href="{{ site.baseurl }}/">Home</a></li>
         {% for node in site.pages reversed %}
-          {% unless node.title == "Home" %}
+          {% unless node.path == "index.md" %}
             {% if node.url == page.url %} <li class="active"> {% else %} <li> {% endif %}
               <a href="{{ node.url | prepend: site.baseurl }}">{{ node.title }}</a></li>
           {% endunless %}

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -9,20 +9,20 @@
       </button>
 
       <p id="llnl-menu-tab" class="pull-left"><a href="https://www.llnl.gov"></a></p>
-      <a class="navbar-brand" href="/">{{ site.name }}</a>
+      <a class="navbar-brand" href="{{ site.baseurl }}/">{{ site.name }}</a>
     </div>
 
     <div id="siteNavbar" class="collapse navbar-collapse">
       <ul class="nav navbar-nav navbar-right navbar-collapse">
-        {% if page.url == "/" %} <li class="active"> {% else %} <li> {% endif %}
-          <a href="{{ site.url }}">Home</a></li>
+        {% if page.title == "Home" %} <li class="active"> {% else %} <li> {% endif %}
+          <a href="{{ site.baseurl }}/">Home</a></li>
         {% for node in site.pages reversed %}
-          {% unless node.url == "/" %}
+          {% unless node.title == "Home" %}
             {% if node.url == page.url %} <li class="active"> {% else %} <li> {% endif %}
-              <a href="{{ node.url | prepend: site.url }}">{{ node.title }}</a></li>
+              <a href="{{ node.url | prepend: site.baseurl }}">{{ node.title }}</a></li>
           {% endunless %}
         {% endfor %}
-        <li id="github"><a href="https://github.com/llnl/{{ site.name }}"><span class="fa fa-github fa-lg"></span></a></li>
+        <li id="github"><a href="https://github.com/llnl/{{ site.githubrepo }}"><span class="fa fa-github fa-lg"></span></a></li>
       </ul>
     </div>
 


### PR DESCRIPTION
Yep, so I broke some links. GitHub project pages are notoriously hard to get right since the root of the website is a subfolder. I.e., root is `llnl.github.io/Jekyll-LLNL-Theme` not `llnl.github.io`.

Details on the solution are here:
http://stackoverflow.com/questions/16316311/github-pages-and-relative-paths
and discussion about this problem is here:
https://github.com/jekyll/jekyll/issues/332

Also, the recommended development practice is to use `--baseurl=''` on the command line, rather than `url: localhost:4000` in the _config.yml file.